### PR TITLE
Fix readme.md link path error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 LG Silicon Valley Lab has developed a Unity-based multi-robot simulator for autonomous vehicle developers. We provide an out-of-the-box solution which can meet the needs of developers wishing to focus on testing their autonomous vehicle algorithms. It currently has integration with the [Duckietown](https://github.com/lgsvl/duckietown2), TierIV's [Autoware](https://github.com/lgsvl/Autoware), and Baidu's [Apollo](https://github.com/lgsvl/apollo) platforms, can generate HD maps, and be immediately used for testing and validation of a whole system with little need for custom integrations. We hope to build a collaborative community among robotics and autonomous vehicle developers by open sourcing our efforts. 
 
-*To use the simulator with Apollo, after following the [build steps](Docs/build-instructions.md) for the simulator, follow the guide on our [Apollo fork](https://github.com/lgsvl/apollo).*
+*To use the simulator with Apollo, after following the [build steps](Docs/docs/build-instructions.md) for the simulator, follow the guide on our [Apollo fork](https://github.com/lgsvl/apollo).*
 
 *To use the simulator with Autoware, build the simulator then follow the guide on our [Autoware fork](https://github.com/lgsvl/Autoware).*
 
@@ -87,7 +87,7 @@ Currently, running the simulator in Windows yields better performance than runni
 
 ### Build standalone executable
 
-If you would prefer to not run in Unity Editor and build the standalone executable yourself, follow the instructions [here](Docs/build-instructions.md).
+If you would prefer to not run in Unity Editor and build the standalone executable yourself, follow the instructions [here](Docs/docs/build-instructions.md).
 
 
 
@@ -95,7 +95,7 @@ If you would prefer to not run in Unity Editor and build the standalone executab
 
 1. After starting the simulator, you should see the main menu. Currently, only Free Roaming mode is supported. Click "Free Roaming." 
 2. Select the appropriate map and vehicle.  For a standard setup, select "SanFrancisco" for map and "XE_Rigged-apollo" for Robot. If connecting with Autoware or Apollo, make sure simulator establishes connection with rosbridge. Click "Run" to begin. The program will not allow running if there is no established connection with a rosbridge. To bypass this and just test out the simulator environment, hold down the Shift button and click "Run."
-3. The vehicle/robot should spawn inside the map environment that was selected. Read [here](Docs/keyboard-shortcuts.md) for an explanation of all current keyboard shortcuts and controls.
+3. The vehicle/robot should spawn inside the map environment that was selected. Read [here](Docs/docs/keyboard-shortcuts.md) for an explanation of all current keyboard shortcuts and controls.
 4. Follow the guides on our respective [Autoware](https://github.com/lgsvl/Autoware) and [Apollo](https://github.com/lgsvl/apollo) repositories for instructions on running the platforms with the simulator.
 
 ![](Docs/docs/images/readme-simulator.jpg)
@@ -104,7 +104,7 @@ If you would prefer to not run in Unity Editor and build the standalone executab
 
 ### Guide to simulator functionality
 
-Look [here](Docs/keyboard-shortcuts.md) for a guide to currently available functionality and keyboard shortcuts for using the simulator.
+Look [here](Docs/docs/keyboard-shortcuts.md) for a guide to currently available functionality and keyboard shortcuts for using the simulator.
 
 
 


### PR DESCRIPTION
Fix readme.md link path error: 
```
Docs/keyboard-shortcuts.md -> Docs/docs/keyboard-shortcuts.md
Docs/build-instructions.md -> Docs/docs/build-instructions.md
```