### PR TITLE
Added Instance Segmentation Sensor type

### DIFF
--- a/Assets/Prefabs/Managers/SimulatorManager.prefab
+++ b/Assets/Prefabs/Managers/SimulatorManager.prefab
@@ -61,25 +61,36 @@ MonoBehaviour:
   SemanticColors:
   - Tag: Car
     Color: {r: 0.07058824, g: 0.05490196, b: 0.5921569, a: 1}
+    AllowInstanceSegmentation: 1
   - Tag: Road
     Color: {r: 0.47843137, g: 0.24705882, b: 0.5137255, a: 1}
+    AllowInstanceSegmentation: 0
   - Tag: Sidewalk
     Color: {r: 0.7294118, g: 0.5137255, b: 0.3137255, a: 1}
+    AllowInstanceSegmentation: 0
   - Tag: Vegetation
     Color: {r: 0.44313726, g: 0.7529412, b: 0.18431373, a: 1}
+    AllowInstanceSegmentation: 0
   - Tag: Obstacle
     Color: {r: 1, g: 1, b: 1, a: 1}
+    AllowInstanceSegmentation: 1
   - Tag: TrafficLight
     Color: {r: 1, g: 1, b: 0, a: 1}
+    AllowInstanceSegmentation: 1
   - Tag: Building
     Color: {r: 0.13725491, g: 0.5254902, b: 0.53333336, a: 1}
+    AllowInstanceSegmentation: 0
   - Tag: Sign
     Color: {r: 0.7529412, g: 0.7529412, b: 0, a: 1}
+    AllowInstanceSegmentation: 1
   - Tag: Shoulder
     Color: {r: 1, g: 0, b: 1, a: 1}
+    AllowInstanceSegmentation: 0
   - Tag: Pedestrian
     Color: {r: 1, g: 0, b: 0, a: 1}
+    AllowInstanceSegmentation: 1
   - Tag: Curb
     Color: {r: 0.28955245, g: 0.14684942, b: 0.31132078, a: 1}
+    AllowInstanceSegmentation: 0
   IsAPI: 0
   FixedUpdateManager: {fileID: 0}

--- a/Assets/Prefabs/Sensors/InstanceSegmentationSensor.prefab
+++ b/Assets/Prefabs/Sensors/InstanceSegmentationSensor.prefab
@@ -1,0 +1,193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &959026166478931016
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1414987604318794648}
+  - component: {fileID: 6454324099872684204}
+  - component: {fileID: 959914374408348488}
+  - component: {fileID: 7985731769012646869}
+  m_Layer: 0
+  m_Name: InstanceSegmentationSensor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1414987604318794648
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959026166478931016}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &6454324099872684204
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959026166478931016}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 7697
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &959914374408348488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959026166478931016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdd86435cb5d25e459a2ffe2da81ec82, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: 
+  Topic: 
+  Frame: 
+  Width: 1920
+  Height: 1080
+  Frequency: 5
+  FieldOfView: 60
+  MinDistance: 0.1
+  MaxDistance: 1000
+--- !u!114 &7985731769012646869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959026166478931016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clearColorMode: 0
+  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
+  clearDepth: 1
+  volumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  volumeAnchorOverride: {fileID: 0}
+  antialiasing: 0
+  SMAAQuality: 2
+  dithering: 0
+  stopNaNs: 0
+  physicalParameters:
+    m_Iso: 200
+    m_ShutterSpeed: 0.005
+    m_Aperture: 16
+    m_BladeCount: 5
+    m_Curvature: {x: 2, y: 11}
+    m_BarrelClipping: 0.25
+    m_Anamorphism: 0
+  flipYMode: 0
+  fullscreenPassthrough: 0
+  customRenderingSettings: 0
+  invertFaceCulling: 0
+  probeLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPathCustomFrameSettings:
+    bitDatas:
+      data1: 69284264410909
+      data2: 4539628424389459968
+  renderingPathCustomFrameSettingsOverrideMask:
+    mask:
+      data1: 0
+      data2: 0
+  defaultFrameSettings: 0
+  m_Version: 5
+  m_ObsoleteRenderingPath: 0
+  m_ObsoleteFrameSettings:
+    overrides: 0
+    enableShadow: 0
+    enableContactShadows: 0
+    enableShadowMask: 0
+    enableSSR: 0
+    enableSSAO: 0
+    enableSubsurfaceScattering: 0
+    enableTransmission: 0
+    enableAtmosphericScattering: 0
+    enableVolumetrics: 0
+    enableReprojectionForVolumetrics: 0
+    enableLightLayers: 0
+    enableExposureControl: 1
+    diffuseGlobalDimmer: 0
+    specularGlobalDimmer: 0
+    shaderLitMode: 0
+    enableDepthPrepassWithDeferredRendering: 0
+    enableTransparentPrepass: 0
+    enableMotionVectors: 0
+    enableObjectMotionVectors: 0
+    enableDecals: 0
+    enableRoughRefraction: 0
+    enableTransparentPostpass: 0
+    enableDistortion: 0
+    enablePostprocess: 0
+    enableOpaqueObjects: 0
+    enableTransparentObjects: 0
+    enableRealtimePlanarReflection: 0
+    enableMSAA: 0
+    enableAsyncCompute: 0
+    runLightListAsync: 0
+    runSSRAsync: 0
+    runSSAOAsync: 0
+    runContactShadowsAsync: 0
+    runVolumeVoxelizationAsync: 0
+    lightLoopSettings:
+      overrides: 0
+      enableDeferredTileAndCluster: 0
+      enableComputeLightEvaluation: 0
+      enableComputeLightVariants: 0
+      enableComputeMaterialVariants: 0
+      enableFptlForForwardOpaque: 0
+      enableBigTilePrepass: 0
+      isFptlEnabled: 0

--- a/Assets/Prefabs/Sensors/InstanceSegmentationSensor.prefab.meta
+++ b/Assets/Prefabs/Sensors/InstanceSegmentationSensor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2ae3265faf047844bb8f190a449c00c4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/RuntimeSettings.asset
+++ b/Assets/Resources/RuntimeSettings.asset
@@ -44,3 +44,4 @@ MonoBehaviour:
   - {fileID: 8926320593265141670, guid: 823225f8334c708988ff56b6fdf3c722, type: 3}
   - {fileID: 6798236283089428316, guid: b916b47d1234714418d5d1b2d71d2f8c, type: 3}
   - {fileID: 3075028223651123413, guid: c14ccc8ff9f29b3438cdd0f4bcebd180, type: 3}
+  - {fileID: 959914374408348488, guid: 2ae3265faf047844bb8f190a449c00c4, type: 3}

--- a/Assets/Scripts/Api/Commands/SensorCameraSave.cs
+++ b/Assets/Scripts/Api/Commands/SensorCameraSave.cs
@@ -38,6 +38,12 @@ namespace Simulator.Api.Commands
                     bool result = camera.Save(path, quality, compression);
                     api.SendResult(result);
                 }
+                else if (sensor is InstanceSegmentationSensor)
+                {
+                    var camera = sensor as InstanceSegmentationSensor;
+                    bool result = camera.Save(path, quality, compression);
+                    api.SendResult(result);
+                }
                 else
                 {
                     api.SendError($"Sensor '{uid}' is not a camera sensor");

--- a/Assets/Scripts/Api/Commands/VehicleGetSensors.cs
+++ b/Assets/Scripts/Api/Commands/VehicleGetSensors.cs
@@ -80,6 +80,22 @@ namespace Simulator.Api.Commands
                         j.Add("far_plane", camera.MaxDistance);
                         j.Add("format", "SEMANTIC");
                     }
+                    else if (sensor is InstanceSegmentationSensor)
+                    {
+                        var camera = sensor as InstanceSegmentationSensor;
+                        var unityCamera = camera.GetComponent<Camera>();
+
+                        j = new JSONObject();
+                        j.Add("type", "camera");
+                        j.Add("name", camera.Name);
+                        j.Add("frequency", camera.Frequency);
+                        j.Add("width", camera.Width);
+                        j.Add("height", camera.Height);
+                        j.Add("fov", camera.FieldOfView);
+                        j.Add("near_plane", camera.MinDistance);
+                        j.Add("far_plane", camera.MaxDistance);
+                        j.Add("format", "INSTANCESEGMENTATION");
+                    }
                     else if (sensor is LidarSensor)
                     {
                         var lidar = sensor as LidarSensor;

--- a/Assets/Scripts/Managers/SimulatorManager.cs
+++ b/Assets/Scripts/Managers/SimulatorManager.cs
@@ -284,38 +284,45 @@ public class SimulatorManager : MonoBehaviour
                 obj.GetComponentsInChildren(true, renderers);
                 renderers.ForEach(renderer =>
                 {
-                    if (Application.isEditor)
+                    if(item.AllowInstanceSegmentation)
                     {
-                        renderer.GetSharedMaterials(sharedMaterials);
                         renderer.GetMaterials(materials);
-
-                        Debug.Assert(sharedMaterials.Count == materials.Count);
-
-                        for (int i = 0; i < materials.Count; i++)
-                        {
-                            if (sharedMaterials[i] == null)
-                            {
-                                Debug.LogError($"{renderer.gameObject.name} has null material", renderer.gameObject);
-                            }
-                            else
-                            {
-                                if (mapping.TryGetValue(sharedMaterials[i], out var mat))
-                                {
-                                    DestroyImmediate(materials[i]);
-                                    materials[i] = mat;
-                                }
-                                else
-                                {
-                                    mapping.Add(sharedMaterials[i], materials[i]);
-                                }
-                            }
-                        }
-
-                        renderer.materials = materials.ToArray();
                     }
                     else
                     {
-                        renderer.GetMaterials(materials);
+                        if (Application.isEditor)
+                        {
+                            renderer.GetSharedMaterials(sharedMaterials);
+                            renderer.GetMaterials(materials);
+
+                            Debug.Assert(sharedMaterials.Count == materials.Count);
+
+                            for (int i = 0; i < materials.Count; i++)
+                            {
+                                if (sharedMaterials[i] == null)
+                                {
+                                    Debug.LogError($"{renderer.gameObject.name} has null material", renderer.gameObject);
+                                }
+                                else
+                                {
+                                    if (mapping.TryGetValue(sharedMaterials[i], out var mat))
+                                    {
+                                        DestroyImmediate(materials[i]);
+                                        materials[i] = mat;
+                                    }
+                                    else
+                                    {
+                                        mapping.Add(sharedMaterials[i], materials[i]);
+                                    }
+                                }
+                            }
+
+                            renderer.materials = materials.ToArray();
+                        }
+                        else
+                        {
+                            renderer.GetSharedMaterials(materials);
+                        }
                     }
                     materials.ForEach(material =>
                     {
@@ -352,7 +359,14 @@ public class SimulatorManager : MonoBehaviour
                 obj.GetComponentsInChildren(true, renderers);
                 renderers.ForEach(renderer =>
                 {
-                    renderer.GetMaterials(materials);
+                    if (Application.isEditor || item.AllowInstanceSegmentation)
+                    {
+                        renderer.GetMaterials(materials);
+                    }
+                    else
+                    {
+                        renderer.GetSharedMaterials(materials);
+                    }
                     
                     materials.ForEach(material =>
                     {

--- a/Assets/Scripts/Managers/SimulatorManager.cs
+++ b/Assets/Scripts/Managers/SimulatorManager.cs
@@ -84,6 +84,7 @@ public class SimulatorManager : MonoBehaviour
     public MonoBehaviour FixedUpdateManager;
     public uint GTIDs { get; set; }
     public uint SignalIDs { get; set; }
+    System.Random rand;
 
     private void Awake()
     {
@@ -133,7 +134,7 @@ public class SimulatorManager : MonoBehaviour
         var config = Loader.Instance?.SimConfig;
 
         var masterSeed = seed ?? config?.Seed ?? new System.Random().Next();
-        System.Random rand = new System.Random(masterSeed);
+        rand = new System.Random(masterSeed);
 
         ManagerHolder = new GameObject("ManagerHolder");
         ManagerHolder.transform.SetParent(transform);
@@ -267,6 +268,19 @@ public class SimulatorManager : MonoBehaviour
         {
             foreach (var obj in GameObject.FindGameObjectsWithTag(item.Tag))
             {
+                Color instanceColor;
+                if(item.AllowInstanceSegmentation)
+                {
+                    instanceColor.a = 1;
+                    instanceColor.r = rand.NextFloat(0.0f, 1.0f);
+                    instanceColor.g = rand.NextFloat(0.0f, 1.0f);
+                    instanceColor.b = rand.NextFloat(0.0f, 1.0f);
+                }
+                else
+                {
+                    instanceColor = item.Color;
+                }
+
                 obj.GetComponentsInChildren(true, renderers);
                 renderers.ForEach(renderer =>
                 {
@@ -303,7 +317,11 @@ public class SimulatorManager : MonoBehaviour
                     {
                         renderer.GetSharedMaterials(materials);
                     }
-                    materials.ForEach(material => material?.SetColor("_SemanticColor", item.Color));
+                    materials.ForEach(material =>
+                    {
+                        material?.SetColor("_SemanticColor", item.Color);
+                        material?.SetColor("_InstanceColor", instanceColor);
+                    });
                 });
             }
         }
@@ -318,6 +336,19 @@ public class SimulatorManager : MonoBehaviour
         {
             if (item.Tag == obj.tag)
             {
+                Color instanceColor;
+                if(item.AllowInstanceSegmentation)
+                {
+                    instanceColor.a = 1;
+                    instanceColor.r = rand.NextFloat(0.0f, 1.0f);
+                    instanceColor.g = rand.NextFloat(0.0f, 1.0f);
+                    instanceColor.b = rand.NextFloat(0.0f, 1.0f);
+                }
+                else
+                {
+                    instanceColor = item.Color;
+                }
+
                 obj.GetComponentsInChildren(true, renderers);
                 renderers.ForEach(renderer =>
                 {
@@ -329,7 +360,11 @@ public class SimulatorManager : MonoBehaviour
                     {
                         renderer.GetSharedMaterials(materials);
                     }
-                    materials.ForEach(material => material?.SetColor("_SemanticColor", item.Color));
+                    materials.ForEach(material =>
+                    {
+                        material?.SetColor("_SemanticColor", item.Color);
+                        material?.SetColor("_InstanceColor", instanceColor);
+                    });
                 });
             }
         }

--- a/Assets/Scripts/Managers/SimulatorManager.cs
+++ b/Assets/Scripts/Managers/SimulatorManager.cs
@@ -315,7 +315,7 @@ public class SimulatorManager : MonoBehaviour
                     }
                     else
                     {
-                        renderer.GetSharedMaterials(materials);
+                        renderer.GetMaterials(materials);
                     }
                     materials.ForEach(material =>
                     {
@@ -352,14 +352,8 @@ public class SimulatorManager : MonoBehaviour
                 obj.GetComponentsInChildren(true, renderers);
                 renderers.ForEach(renderer =>
                 {
-                    if (Application.isEditor)
-                    {
-                        renderer.GetMaterials(materials);
-                    }
-                    else
-                    {
-                        renderer.GetSharedMaterials(materials);
-                    }
+                    renderer.GetMaterials(materials);
+                    
                     materials.ForEach(material =>
                     {
                         material?.SetColor("_SemanticColor", item.Color);

--- a/Assets/Scripts/Sensors/DefaultSensors.cs
+++ b/Assets/Scripts/Sensors/DefaultSensors.cs
@@ -113,6 +113,10 @@ namespace Simulator.Sensors
             ""params"": { ""Width"": 1920, ""Height"": 1080, ""Frequency"": 15, ""FieldOfView"": 50, ""MinDistance"": 0.1, ""MaxDistance"": 1000, ""Topic"": ""/simulator/semantic_camera/compressed"" },
             ""transform"": { ""x"": 0, ""y"": 1.7, ""z"": -0.2, ""pitch"": 0, ""yaw"": 0, ""roll"": 0 }}",
 
+            @"{""type"": ""Instance Segmentation Camera"", ""name"": ""Instance Segmentation Camera"",
+            ""params"": { ""Width"": 1920, ""Height"": 1080, ""Frequency"": 15, ""FieldOfView"": 50, ""MinDistance"": 0.1, ""MaxDistance"": 1000, ""Topic"": ""/simulator/instance_segmentation_camera/compressed"" },
+            ""transform"": { ""x"": 0, ""y"": 1.7, ""z"": -0.2, ""pitch"": 0, ""yaw"": 0, ""roll"": 0 }}",
+
             @"{""type"": ""3D Ground Truth"", ""name"": ""3D Ground Truth"",
             ""params"": { ""Frequency"": 10, ""Topic"": ""/simulator/ground_truth/3d_detections"" },
             ""transform"": { ""x"": 0, ""y"": 1.975314, ""z"": -0.3679201, ""pitch"": 0, ""yaw"": 0, ""roll"": 0 }}",

--- a/Assets/Scripts/Sensors/InstanceSegmentationSensor.cs
+++ b/Assets/Scripts/Sensors/InstanceSegmentationSensor.cs
@@ -1,0 +1,313 @@
+/**
+ * Copyright (c) 2019 Daimler Autonomous Services
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unity.Collections;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+using Simulator.Bridge;
+using Simulator.Bridge.Data;
+using Simulator.Plugins;
+using Simulator.Utilities;
+using Simulator.Sensors.UI;
+
+namespace Simulator.Sensors
+{
+    [SensorType("Instance Segmentation Camera", new[] {typeof(ImageData)})]
+    [RequireComponent(typeof(Camera))]
+    public class InstanceSegmentationSensor : SensorBase
+    {
+        [SensorParameter]
+        [Range(1, 1920)]
+        public int Width = 1920;
+
+        [SensorParameter]
+        [Range(1, 1080)]
+        public int Height = 1080;
+
+        [SensorParameter]
+        [Range(1, 100)]
+        public int Frequency = 5;
+
+        [SensorParameter]
+        [Range(1.0f, 90.0f)]
+        public float FieldOfView = 60.0f;
+
+        [SensorParameter]
+        [Range(0.01f, 1000.0f)]
+        public float MinDistance = 0.1f;
+
+        [SensorParameter]
+        [Range(0.01f, 2000.0f)]
+        public float MaxDistance = 1000.0f;
+
+        IWriter<ImageData> ImageWriter;
+        ImageData Data;
+
+        IBridge Bridge;
+
+        const int MaxJpegSize = 4 * 1024 * 1024; // 4MB
+
+        private Camera Camera;
+
+        private float nextCaptureTime = 0.0f;
+
+        private bool capturePending = false;
+
+        private struct CameraCapture
+        {
+            public AsyncGPUReadbackRequest readbackRequest;
+
+            public double captureTime;
+
+            public CameraCapture(AsyncGPUReadbackRequest request)
+            {
+                readbackRequest = request;
+                captureTime = SimulatorManager.Instance.CurrentTime;
+            }
+        }
+
+        private Queue<CameraCapture> captureQueue = new Queue<CameraCapture>();
+        
+        public void Start()
+        {
+            Camera = GetComponent<Camera>();
+            Camera.enabled = false;
+
+            Camera.GetComponent<HDAdditionalCameraData>().customRender += CustomRender;
+
+            Data = new ImageData()
+            {
+                Name = Name,
+                Frame = Frame,
+                Width = Width,
+                Height = Height,
+                Bytes = new byte[MaxJpegSize],
+            };
+        }
+
+        void CustomRender(ScriptableRenderContext context, HDCamera hd)
+        {
+            var camera = hd.camera;
+            
+            ScriptableCullingParameters culling;
+            if (camera.TryGetCullingParameters(out culling))
+            {
+                var cull = context.Cull(ref culling);
+
+                context.SetupCameraProperties(camera);
+
+                var cmd = CommandBufferPool.Get();
+                hd.SetupGlobalParams(cmd, 0, 0, 0);
+                cmd.ClearRenderTarget(true, true, SimulatorManager.Instance.SemanticSkyColor);
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
+
+                var sorting = new SortingSettings(camera);
+                var drawing = new DrawingSettings(new ShaderTagId("SimulatorInstanceSegmentationPass"), sorting);
+                var filter = new FilteringSettings(RenderQueueRange.all);
+
+                context.DrawRenderers(cull, ref drawing, ref filter);
+            }
+        }
+
+        public void OnDestroy()
+        {
+            Camera.targetTexture?.Release();
+        }
+
+        public override void OnBridgeSetup(IBridge bridge)
+        {
+            Bridge = bridge;
+            ImageWriter = bridge.AddWriter<ImageData>(Topic);
+        }
+
+        public void Update()
+        {
+            Camera.fieldOfView = FieldOfView;
+            Camera.nearClipPlane = MinDistance;
+            Camera.farClipPlane = MaxDistance;
+
+            CheckTexture();
+            CheckCapture();
+            ProcessReadbackRequests();
+        }
+
+        void CheckTexture()
+        {
+            // if this is not first time
+            if (Camera.targetTexture != null)
+            {
+                if (Width != Camera.targetTexture.width || Height != Camera.targetTexture.height)
+                {
+                    // if camera capture size has changed
+                    Data.Width = Width;
+                    Data.Height = Height;
+
+                    Camera.targetTexture.Release();
+                    Camera.targetTexture = null;
+                }
+                else if (!Camera.targetTexture.IsCreated())
+                {
+                    // if we have lost rendertexture due to Unity window resizing or otherwise
+                    Camera.targetTexture.Release();
+                    Camera.targetTexture = null;
+                }
+            }
+
+            if (Camera.targetTexture == null)
+            {
+                Camera.targetTexture = new RenderTexture(Width, Height, 24, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear)
+                {
+                    dimension = TextureDimension.Tex2D,
+                    antiAliasing = 1,
+                    useMipMap = false,
+                    useDynamicScale = false,
+                    wrapMode = TextureWrapMode.Clamp,
+                    filterMode = FilterMode.Bilinear,
+                };
+            }
+        }
+
+		void CheckCapture()
+        {
+            if(capturePending)
+            {
+                TriggerCapture();
+            }
+
+            if(Time.time >= nextCaptureTime)
+            {
+                nextCaptureTime = Time.time + (1.0f / Frequency);
+                capturePending = true;
+                Camera.enabled = true;
+            }
+        }
+
+        void TriggerCapture()
+        {
+            var readbackRequest = AsyncGPUReadback.Request(Camera.targetTexture, 0, TextureFormat.RGBA32);
+            var capture = new CameraCapture(readbackRequest);
+            captureQueue.Enqueue(capture);
+            Camera.enabled = false;
+            capturePending = false;
+        }
+
+        void ProcessReadbackRequests()
+        {
+            while(captureQueue.Count > 0)
+            {
+                var capture = captureQueue.Peek();
+                if(capture.readbackRequest.hasError)
+                {
+                    Debug.Log("Failed to read GPU texture");
+                    captureQueue.Dequeue();
+                }
+                else if(capture.readbackRequest.done)
+                {
+                    var data = capture.readbackRequest.GetData<byte>();
+                    captureQueue.Dequeue();
+                    var imageData = new ImageData()
+                    {
+                        Name = Name,
+                        Frame = Frame,
+                        Width = Width,
+                        Height = Height,
+                        Bytes = new byte[MaxJpegSize],
+                        Sequence = Data.Sequence,
+                    };
+                    
+                    if (Bridge != null && Bridge.Status == Status.Connected)
+                    {
+                        Task.Run(() =>
+                        {
+                            imageData.Length = JpegEncoder.Encode(data, Width, Height, 4, 100, imageData.Bytes);
+                            if (imageData.Length > 0)
+                            {
+                                imageData.Time = capture.captureTime;
+                                ImageWriter.Write(imageData);
+                            }
+                            else
+                            {
+                                Debug.Log("Compressed image is empty, length = 0");
+                            }
+                        });
+                    }
+
+                    Data.Sequence++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        public bool Save(string path, int quality, int compression)
+        {
+            CheckTexture();
+            Camera.Render();
+            var readback = AsyncGPUReadback.Request(Camera.targetTexture, 0, TextureFormat.RGBA32);
+            readback.WaitForCompletion();
+
+            if (readback.hasError)
+            {
+                Debug.Log("Failed to read GPU texture");
+                return false;
+            }
+
+            Debug.Assert(readback.done);
+            var data = readback.GetData<byte>();
+
+            var bytes = new byte[16 * 1024 * 1024];
+            int length;
+
+            var ext = System.IO.Path.GetExtension(path).ToLower();
+
+            if (ext == ".png")
+            {
+                length = PngEncoder.Encode(data, Width, Height, 4, compression, bytes);
+            }
+            else if (ext == ".jpeg" || ext == ".jpg")
+            {
+                length = JpegEncoder.Encode(data, Width, Height, 4, quality, bytes);
+            }
+            else
+            {
+                return false;
+            }
+
+            if (length > 0)
+            {
+                try
+                {
+                    using (var file = System.IO.File.Create(path))
+                    {
+                        file.Write(bytes, 0, length);
+                    }
+                    return true;
+                }
+                catch
+                {
+                }
+            }
+
+            return false;
+        }
+
+        public override void OnVisualize(Visualizer visualizer)
+        {
+            Debug.Assert(visualizer != null);
+            visualizer.UpdateRenderTexture(Camera.activeTexture, Camera.aspect);
+        }
+
+        public override void OnVisualizeToggle(bool state)
+        {
+            //
+        }
+    }
+}

--- a/Assets/Scripts/Sensors/InstanceSegmentationSensor.cs.meta
+++ b/Assets/Scripts/Sensors/InstanceSegmentationSensor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdd86435cb5d25e459a2ffe2da81ec82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/SemanticColor.cs
+++ b/Assets/Scripts/Utilities/SemanticColor.cs
@@ -16,5 +16,6 @@ namespace Simulator.Utilities
         [TagSelector]
         public string Tag;
         public Color Color;
+        public bool AllowInstanceSegmentation;
     }
 }

--- a/Assets/Shaders/InstanceSegmentationPass.hlsl
+++ b/Assets/Shaders/InstanceSegmentationPass.hlsl
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019 Daimler Autonomous Services
+ */
+
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VertMesh.hlsl"
+
+PackedVaryingsType Vert(AttributesMesh inputMesh)
+{
+    VaryingsType varyingsType;
+    varyingsType.vmesh = VertMesh(inputMesh);
+    return PackVaryingsType(varyingsType);
+}
+
+void Frag(PackedVaryingsToPS packedInput,
+        out float4 outColor : SV_Target
+        #ifdef _DEPTHOFFSET_ON
+            , out float outputDepth : SV_Depth
+        #endif
+          )
+{
+#if defined(_SURFACE_TYPE_TRANSPARENT) || defined(_DEPTHOFFSET_ON)
+    FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz);
+#endif
+
+#if defined(_SURFACE_TYPE_TRANSPARENT)
+    float3 V = float3(1.0, 1.0, 1.0);
+
+    SurfaceData surfaceData;
+    BuiltinData builtinData;
+    GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
+
+    clip(builtinData.opacity - 0.5);
+#endif
+
+    outColor = _InstanceColor;
+
+#ifdef _DEPTHOFFSET_ON
+    outputDepth = posInput.deviceDepth;
+#endif
+}

--- a/Assets/Shaders/InstanceSegmentationPass.hlsl.meta
+++ b/Assets/Shaders/InstanceSegmentationPass.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 627ccdf40afaa714e8f88e204bfccb67
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/Packages/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -916,6 +916,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = new Color(0.0f, 0.0f, 0.0f, 1.0f)
             });
 
+            collector.AddShaderProperty(new ColorShaderProperty()
+            {
+                overrideReferenceName = "_InstanceColor",
+                hidden = true,
+                value = new Color(0.0f, 0.0f, 0.0f, 1.0f)
+            });
+
             base.CollectShaderProperties(collector, generationMode);
         }
     }

--- a/Packages/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/Packages/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -640,6 +640,30 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
         };
 
+        Pass m_PassSimulatorInstanceSegmentation = new Pass()
+        {
+            Name = "SimulatorInstanceSegmentationPass",
+            LightMode = "SimulatorInstanceSegmentationPass",
+            TemplateName = "HDLitPass.template",
+            MaterialName = "Lit",
+            ShaderPassName = "SHADERPASS_SIMULATOR_INSTANCE_SEGMENTATION",
+            Includes = new List<string>()
+            {
+                "#include \"Assets/Shaders/InstanceSegmentationPass.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                HDLitMasterNode.AlbedoSlotId,
+                HDLitMasterNode.AlphaSlotId,
+                HDLitMasterNode.AlphaThresholdSlotId,
+                HDLitMasterNode.DepthOffsetSlotId,
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                HDLitMasterNode.PositionSlotId,
+            },
+        };
+
         Pass m_PassSimulatorDepth = new Pass()
         {
             Name = "SimulatorDepthPass",
@@ -1195,6 +1219,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
                 GenerateShaderPassLit(masterNode, m_PassSimulatorLidar, mode, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassLit(masterNode, m_PassSimulatorSemantic, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPassLit(masterNode, m_PassSimulatorInstanceSegmentation, mode, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassLit(masterNode, m_PassSimulatorDepth, mode, subShader, sourceAssetDependencyPaths);
             }
             subShader.Deindent();

--- a/Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -234,6 +234,7 @@ Shader "HDRP/Lit"
         [HideInInspector] _DiffusionProfileHash("Diffusion Profile Hash", Float) = 0
 
         [HideInInspector] _SemanticColor("Semantic Color", Color) = (0, 0, 0, 1)
+        [HideInInspector] _InstanceColor("Instance Color", Color) = (0, 0, 0, 1)
     }
 
     HLSLINCLUDE
@@ -817,6 +818,29 @@ Shader "HDRP/Lit"
             #pragma fragment Frag
 
             #include "Assets/Shaders/SemanticPass.hlsl"
+
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "SimulatorInstanceSegmentationPass"
+            Tags { "LightMode" = "SimulatorInstanceSegmentationPass" }
+
+            HLSLPROGRAM
+
+            #define ATTRIBUTES_NEED_TEXCOORD0
+            #define VARYINGS_NEED_TEXCOORD0
+
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.cs.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VaryingMesh.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl"
+
+            #pragma vertex Vert
+            #pragma fragment Frag
+
+            #include "Assets/Shaders/InstanceSegmentationPass.hlsl"
 
             ENDHLSL
         }

--- a/Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
+++ b/Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
@@ -288,5 +288,6 @@ int _ObjectId;
 int _PassValue;
 
 float4 _SemanticColor;
+float4 _InstanceColor;
 
 CBUFFER_END


### PR DESCRIPTION
Based on Semantic Segmentation Sensor, created Instance Segmentation Sensor type. Assigns random color to object instances of specific categories (eg cars, pedestrians etc.). For users working with downloaded content, this will work only partially because in the downloaded content, the new shader pass isn't known, resulting in only objects rendering that have their materials outside the downloaded packages (this is true for AI vehicles and pedestrians). Once LG takes this change and rebuilds their content, this will be fixed.