### PR TITLE
Retrieving BridgePlugin by name, not a type

### DIFF
--- a/Assets/Scripts/Managers/AgentManager.cs
+++ b/Assets/Scripts/Managers/AgentManager.cs
@@ -97,7 +97,7 @@ public class AgentManager : MonoBehaviour
             Simulator.Web.Config.CheckDir(vfs.GetChild(config.BridgeData.AssetGuid), Simulator.Web.Config.LoadBridgePlugin);
 
             bridgeClient = go.AddComponent<BridgeClient>();
-            config.Bridge = BridgePlugins.Get(config.BridgeData.Type);
+            config.Bridge = BridgePlugins.Get(config.BridgeData.Name);
             bridgeClient.Init(config.Bridge);
 
             if (!String.IsNullOrEmpty(config.Connection))


### PR DESCRIPTION
`BridgePlugins.Get(...)` expects a name of a bridge, not its type.

This fixes resolving a correct BridgePlugin for custom bridges whose `type != name` (accidentally every SVL core bridge name matches its type). 