### PR TITLE
Fix issues with collided vehicle not being detected

### DIFF
--- a/Assets/Scripts/Controllers/VehicleController.cs
+++ b/Assets/Scripts/Controllers/VehicleController.cs
@@ -213,7 +213,7 @@ public class VehicleController : AgentController
         var otherVel = otherRB != null ? otherRB.Velocity : Vector3.zero;
         if ((layerMask & (1 << layer)) != 0)
         {
-            ApiManager.Instance?.AddCollision(gameObject, collision.gameObject);
+            ApiManager.Instance?.AddCollision(gameObject, collision.attachedRigidbody.gameObject);
             SimulatorManager.Instance.AnalysisManager.IncrementEgoCollision(Controller.GTID, transform.position, Dynamics.Velocity, otherVel, otherLayer);
         }
     }


### PR DESCRIPTION
When `on_collision` is set on the ego vehicle and it collides with a npc, we notice that Python API returns NULL through the ws socket with lgsvl:
```json
{"result":{"events":[{"type":"collision","agent":"eb657a86-0d2a-4bd5-9d91-184469100ee7","other":null,"contact":{"x":107.696556091309,"y":0.237456381320953,"z":32.5612945556641}}]}}
``` 

Obviously that `other` object in `AddCollision()` is not corresponded with added agent objects before:
https://github.com/lgsvl/simulator/blob/26b53c1c44cb32e396d7c81f45052e3930ed7d88/Assets/Scripts/Api/ApiManager.cs#L350-L370

We notice implementation of `OnTriggerEnter` in `VehicleController.cs` is a bit different from that in `NPCController.cs`. After modifying `collision.gameObject` to `collision.attachedRigidbody.gameObject`, the collided vehicles can be successfully resolved.